### PR TITLE
Allow journal managers to configure Twitter block

### DIFF
--- a/TwitterBlockPlugin.inc.php
+++ b/TwitterBlockPlugin.inc.php
@@ -3,10 +3,10 @@ import('lib.pkp.classes.plugins.BlockPlugin');
 
 class TwitterBlockPlugin extends BlockPlugin
 {
-	//enables plugin site-wide
+	// Enables plugin site-wide or in specific context; this must return true only if the user is in the site-wide context
 	public function isSitePlugin()
 	{
-		return true;
+		return !Application::get()->getRequest()->getContext();
 	}
 
 	public function getDisplayName()


### PR DESCRIPTION
At the moment, only system administrators can see the Twitter block in their plugins - journal managers don't see it.

The reason for it is that the `isSitePlugin` function gets used by OJS (see https://github.com/pkp/customBlockManager/blob/89a98b7015e13dfbb1e8c73fe046f9ca471f373b/CustomBlockManagerPlugin.inc.php#L138-L141) to grant access to users, meaning that with it returning `true`, only system administrators (not journal managers) get the ability to configure the Twitter block. 

This change still allows the block to be configured either on a site-wide or journal/context-specific basis, just that journal managers can configure the settings on their journals. 

This change follows the same pattern used by other built-in plugins like https://github.com/pkp/customBlockManager/blob/master/CustomBlockManagerPlugin.inc.php#L147 and https://github.com/pkp/customHeader/blob/master/CustomHeaderPlugin.inc.php#L146